### PR TITLE
Dotnet platform standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - nuget restore BencodeNET.sln
   - nuget install xunit.runner.console -Version 2.0.0 -OutputDirectory xunit
 script:
-  - xbuild /p:Configuration=Release BencodeNET.sln
+  - xbuild /p:Configuration=MonoRelease BencodeNET.sln
   - mono ./xunit/xunit.runner.console.2.0.0/tools/xunit.console.exe ./BencodeNET.Tests/bin/Release/BencodeNET.Tests.dll
   
   

--- a/BencodeNET.Net45/Exceptions/BencodeDecodingException.cs
+++ b/BencodeNET.Net45/Exceptions/BencodeDecodingException.cs
@@ -4,7 +4,9 @@ using BencodeNET.Objects;
 
 namespace BencodeNET.Exceptions
 {
+#if !NETSTANDARD
     [Serializable]
+#endif
     public class BencodeDecodingException<T> : Exception
     {
         public long StreamPosition { get; set; }
@@ -49,6 +51,7 @@ namespace BencodeNET.Exceptions
             return output;
         }
 
+#if !NETSTANDARD
         protected BencodeDecodingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -64,5 +67,6 @@ namespace BencodeNET.Exceptions
 
             info.AddValue("StreamPosition", StreamPosition);
         }
+#endif
     }
 }

--- a/BencodeNET.Net45/Exceptions/UnsupportedBencodeException.cs
+++ b/BencodeNET.Net45/Exceptions/UnsupportedBencodeException.cs
@@ -3,7 +3,9 @@ using System.Runtime.Serialization;
 
 namespace BencodeNET.Exceptions
 {
+#if !NETSTANDARD
     [Serializable]
+#endif
     public class UnsupportedBencodeException : Exception
     {
         public long StreamPosition { get; set; }
@@ -34,6 +36,7 @@ namespace BencodeNET.Exceptions
             return message;
         }
 
+#if !NETSTANDARD
         protected UnsupportedBencodeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -49,5 +52,6 @@ namespace BencodeNET.Exceptions
 
             info.AddValue("StreamPosition", StreamPosition);
         }
+#endif
     }
 }

--- a/BencodeNET.Net45/IO/BencodeStream.cs
+++ b/BencodeNET.Net45/IO/BencodeStream.cs
@@ -218,7 +218,7 @@ namespace BencodeNET.IO
             if (disposing)
             {
                 if (_stream != null && !_leaveOpen)
-                    _stream.Close();
+                    _stream.Dispose();
                 _stream = null;
             }
         }

--- a/BencodeNET.Net45/Objects/TorrentFile.cs
+++ b/BencodeNET.Net45/Objects/TorrentFile.cs
@@ -119,7 +119,7 @@ namespace BencodeNET.Objects
 
         public static byte[] CalculateInfoHashBytes(BDictionary info)
         {
-            using (var sha1 = new SHA1Managed())
+            using (var sha1 = SHA1.Create())
             using (var ms = new MemoryStream())
             {
                 info.EncodeToStream(ms);

--- a/BencodeNET.Standard/BencodeNET.Standard.csproj
+++ b/BencodeNET.Standard/BencodeNET.Standard.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{103D64D8-255A-40F4-8F86-DB62CF95CAB5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BencodeNET</RootNamespace>
+    <AssemblyName>BencodeNET</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETSTANDARD</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\BencodeNET.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\BencodeNET.Net45\Bencode.cs">
+      <Link>Bencode.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Exceptions\BencodeDecodingException.cs">
+      <Link>Exceptions\BencodeDecodingException.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Exceptions\UnsupportedBencodeException.cs">
+      <Link>Exceptions\UnsupportedBencodeException.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\IO\BencodeStream.cs">
+      <Link>IO\BencodeStream.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\BDictionary.cs">
+      <Link>Objects\BDictionary.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\BList.cs">
+      <Link>Objects\BList.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\BNumber.cs">
+      <Link>Objects\BNumber.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\BObject.cs">
+      <Link>Objects\BObject.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\BString.cs">
+      <Link>Objects\BString.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\IBObject.cs">
+      <Link>Objects\IBObject.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\Objects\TorrentFile.cs">
+      <Link>Objects\TorrentFile.cs</Link>
+    </Compile>
+    <Compile Include="..\BencodeNET.Net45\UtilityExtensions.cs">
+      <Link>UtilityExtensions.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/BencodeNET.Standard/Properties/AssemblyInfo.cs
+++ b/BencodeNET.Standard/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BencodeNET")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BencodeNET")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2ee80344-055d-4b7e-8af7-49c4832830e8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.3.1")]
+[assembly: AssemblyFileVersion("1.3.1")]

--- a/BencodeNET.Standard/project.json
+++ b/BencodeNET.Standard/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "supports": {},
+  "dependencies": {
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.0",
+    "System.Security.Cryptography.Algorithms": "4.2.0"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}

--- a/BencodeNET.sln
+++ b/BencodeNET.sln
@@ -29,27 +29,37 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		MonoRelease|Any CPU = MonoRelease|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A267EADE-6093-41DF-AB20-53CB9661B47B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A267EADE-6093-41DF-AB20-53CB9661B47B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A267EADE-6093-41DF-AB20-53CB9661B47B}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{A267EADE-6093-41DF-AB20-53CB9661B47B}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{A267EADE-6093-41DF-AB20-53CB9661B47B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A267EADE-6093-41DF-AB20-53CB9661B47B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EEEE6947-258B-4E6E-AE99-F72B7A29D96F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EEEE6947-258B-4E6E-AE99-F72B7A29D96F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEEE6947-258B-4E6E-AE99-F72B7A29D96F}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{EEEE6947-258B-4E6E-AE99-F72B7A29D96F}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{EEEE6947-258B-4E6E-AE99-F72B7A29D96F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEEE6947-258B-4E6E-AE99-F72B7A29D96F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B72053C7-01F2-47EC-AAF3-8A4FC078AF1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B72053C7-01F2-47EC-AAF3-8A4FC078AF1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B72053C7-01F2-47EC-AAF3-8A4FC078AF1D}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{B72053C7-01F2-47EC-AAF3-8A4FC078AF1D}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{B72053C7-01F2-47EC-AAF3-8A4FC078AF1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B72053C7-01F2-47EC-AAF3-8A4FC078AF1D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/BencodeNET.sln
+++ b/BencodeNET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BencodeNET.Net45", "BencodeNET.Net45\BencodeNET.Net45.csproj", "{A267EADE-6093-41DF-AB20-53CB9661B47B}"
 EndProject
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{4EA69A14
 	ProjectSection(SolutionItems) = preProject
 		Package\BencodeNET.nuspec = Package\BencodeNET.nuspec
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BencodeNET.Standard", "BencodeNET.Standard\BencodeNET.Standard.csproj", "{103D64D8-255A-40F4-8F86-DB62CF95CAB5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -46,6 +48,10 @@ Global
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BAC8D29-CAED-4940-BC0B-3E4F8EDB74F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{103D64D8-255A-40F4-8F86-DB62CF95CAB5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Package/BencodeNET.nuspec
+++ b/Package/BencodeNET.nuspec
@@ -12,6 +12,13 @@
     <releaseNotes>Better handling of CreationDate in torrent files. Added some XML documentation.</releaseNotes>
     <copyright></copyright>
     <tags>bencode torrent torrents</tags>
+
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.2.0" />
+      </group>
+    </dependencies>
+
   </metadata>
   <files>
     <file src="BencodeNET.Net35\bin\Release\BencodeNET.dll" target="lib\net35" />
@@ -25,5 +32,9 @@
     <file src="BencodeNET.Net45\bin\Release\BencodeNET.dll" target="lib\net45" />
     <file src="BencodeNET.Net45\bin\Release\BencodeNET.pdb" target="lib\net45" />
     <file src="BencodeNET.Net45\bin\Release\BencodeNET.xml" target="lib\net45" />
+
+    <file src="BencodeNET.Standard\bin\Release\BencodeNET.dll" target="lib\netstandard1.3" />
+    <file src="BencodeNET.Standard\bin\Release\BencodeNET.pdb" target="lib\netstandard1.3" />
+    <file src="BencodeNET.Standard\bin\Release\BencodeNET.xml" target="lib\netstandard1.3" />
   </files>
 </package>


### PR DESCRIPTION
Added the .NET Platform Standard as a target. This allows using the library in .NET Core apps in addition to under the full .NET Framework.

I've added this to the nuspec file, but the version of nuget.exe checked in to this project doesn't support netstandard1.3 as a target, so it would need to be updated to build the Nuget package.
