### PR TITLE
Add casting operators for int? and long?

### DIFF
--- a/BencodeNET.Tests/Objects/BNumberTests.cs
+++ b/BencodeNET.Tests/Objects/BNumberTests.cs
@@ -191,6 +191,53 @@ namespace BencodeNET.Tests.Objects
             bnumber.Should().BeNull();
         }
 
+        [Fact]
+        public void CanCastToInt()
+        {
+            BNumber bnumber = new BNumber(12345);
+            int number = (int)bnumber;
+            number.Should().Be(12345);
+        }
+
+        [Fact]
+        public void CanCastToLong()
+        {
+            BNumber bnumber = new BNumber(12345);
+            long number = (long)bnumber;
+            number.Should().Be(12345);
+        }
+
+        [Fact]
+        public void CanCastToNullableInt_WhenNull()
+        {
+            BNumber bnumber = null;
+            var number = (int?)bnumber;
+            number.Should().BeNull();
+        }
+
+        [Fact]
+        public void CanCastToNullableLong_WhenNull()
+        {
+            BNumber bnumber = null;
+            var number = (long?)bnumber;
+            number.Should().BeNull();
+        }
+
+        [Fact]
+        public void CanCastToNullableInt_WhenNotNull()
+        {
+            BNumber bnumber = 12345;
+            var number = (int?)bnumber;
+            number.Should().Be(12345);
+        }
+
+        [Fact]
+        public void CanCastToNullableLong_WhenNotNull()
+        {
+            BNumber bnumber = 12345;
+            var number = (long?)bnumber;
+            number.Should().Be(12345);
+        }
 
         [Fact]
         public void CanCastFromDateTime()

--- a/BencodeNET.Tests/Objects/BNumberTests.cs
+++ b/BencodeNET.Tests/Objects/BNumberTests.cs
@@ -160,6 +160,39 @@ namespace BencodeNET.Tests.Objects
         }
 
         [Fact]
+        public void CanCastFromInt()
+        {
+            int number = 12345;
+            var bnumber = (BNumber)number;
+            bnumber.Should().Be(12345);
+        }
+
+        [Fact]
+        public void CanCastFromLong()
+        {
+            long number = 12345;
+            var bnumber = (BNumber)number;
+            bnumber.Should().Be(12345);
+        }
+
+        [Fact]
+        public void CanCastFromNullableInt()
+        {
+            int? number = null;
+            var bnumber = (BNumber)number;
+            bnumber.Should().BeNull();
+        }
+
+        [Fact]
+        public void CanCastFromNullableLong()
+        {
+            long? number = null;
+            var bnumber = (BNumber)number;
+            bnumber.Should().BeNull();
+        }
+
+
+        [Fact]
         public void CanCastFromDateTime()
         {
             var bnumber = (BNumber) new DateTime(2016, 1, 1);

--- a/BencodeNET.Tests/Objects/BNumberTests.cs
+++ b/BencodeNET.Tests/Objects/BNumberTests.cs
@@ -176,7 +176,7 @@ namespace BencodeNET.Tests.Objects
         }
 
         [Fact]
-        public void CanCastFromNullableInt()
+        public void CanCastFromNullableInt_WhenNull()
         {
             int? number = null;
             var bnumber = (BNumber)number;
@@ -184,11 +184,27 @@ namespace BencodeNET.Tests.Objects
         }
 
         [Fact]
-        public void CanCastFromNullableLong()
+        public void CanCastFromNullableLong_WhenNull()
         {
             long? number = null;
             var bnumber = (BNumber)number;
             bnumber.Should().BeNull();
+        }
+
+        [Fact]
+        public void CanCastFromNullableInt_WhenNotNull()
+        {
+            int? number = 12345;
+            var bnumber = (BNumber)number;
+            bnumber.Should().Be(12345);
+        }
+
+        [Fact]
+        public void CanCastFromNullableLong_WhenNotNull()
+        {
+            long? number = 12345;
+            var bnumber = (BNumber)number;
+            bnumber.Should().Be(12345);
         }
 
         [Fact]

--- a/BencodeNET/Objects/BNumber.cs
+++ b/BencodeNET/Objects/BNumber.cs
@@ -49,6 +49,18 @@ namespace BencodeNET.Objects
             stream.Write(Value);
             stream.Write('e');
         }
+        
+        public static implicit operator int?(BNumber bint)
+        {
+            if (bint == null) return null;
+            return (int)bint.Value;
+        }
+
+        public static implicit operator long?(BNumber bint)
+        {
+            if (bint == null) return null;
+            return bint.Value;
+        }
 
         public static implicit operator int(BNumber bint)
         {


### PR DESCRIPTION
With this change I try to fix the following case:
```
 return new KrpcQuery
 {
         Id = queryDictionary.Get<BString>("id")?.ToString(),
         InfoHash = queryDictionary.Get<BString>("info_hash")?.ToString(),
         Target = queryDictionary.Get<BString>("target")?.ToString(),
         ImpliedPort = queryDictionary.Get<BNumber>("implied_port"), // ImpliedPort is an int?
         Token = queryDictionary.Get<BString>("token")?.ToString()
 };
```
This throws InvalidCastException, when try to get "implied_port" key, I want to get null if does not exist in the dictionary.