### PR TITLE
Uri encode tracker urls in magnet links

### DIFF
--- a/BencodeNET/Torrents/TorrentUtil.cs
+++ b/BencodeNET/Torrents/TorrentUtil.cs
@@ -124,7 +124,7 @@ namespace BencodeNET.Torrents
 
             if (options.HasFlag(MagnetLinkOptions.IncludeTrackers) && validTrackers.Any())
             {
-                var trackersString = string.Join("&", validTrackers.Select(x => $"tr={x}"));
+                var trackersString = string.Join("&", validTrackers.Select(x => $"tr={Uri.EscapeDataString(x)}"));
                 magnet += $"&{trackersString}";
             }
 


### PR DESCRIPTION
I noticed that the magnet links are including un-escaped tracker urls, this breaks some client parsers